### PR TITLE
Replaced base URL with sci-hub.st

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@
 const doiRegex = new RegExp(
   /\b(10[.][0-9]{4,}(?:[.][0-9]+)*\/(?:(?!["&\'<>])\S)+)\b/
 );
-const sciHubUrl = "https://sci-hub.tw/";
+const sciHubUrl = "https://sci-hub.st/";
 const trueRed = "#BC243C";
 
 function resetBadgeText() {


### PR DESCRIPTION
Since sci-hub.tw is unavailable at the time, this change of the base URL fixes the addon.