### PR TITLE
"Options" page to set scihub URL

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@
 const doiRegex = new RegExp(
   /\b(10[.][0-9]{4,}(?:[.][0-9]+)*\/(?:(?!["&\'<>])\S)+)\b/
 );
-const sciHubUrl = "https://sci-hub.tw/";
+const sciHubUrl = "https://sci-hub.st/";
 const trueRed = "#BC243C";
 
 function resetBadgeText() {

--- a/background.js
+++ b/background.js
@@ -3,12 +3,26 @@
 const doiRegex = new RegExp(
   /\b(10[.][0-9]{4,}(?:[.][0-9]+)*\/(?:(?!["&\'<>])\S)+)\b/
 );
-const sciHubUrl = "https://sci-hub.st/";
+
+var sciHubUrl;
 const trueRed = "#BC243C";
 
 function resetBadgeText() {
   browser.browserAction.setBadgeText({ text: "" });
 }
+
+function setUrl(url) {
+  sciHubUrl = url;
+};
+function iniitalizeUrl () {
+  chrome.storage.local.get(["scihub-url"], function (result) {
+    if (!("scihub-url" in result)) {
+      result["scihub-url"] = "https://sci-hub.st/";
+      chrome.storage.local.set(result, function () {});
+    }
+    sciHubUrl = result["scihub-url"];
+  });
+};
 
 function getHtml(htmlSource) {
   htmlSource = htmlSource[0];
@@ -48,3 +62,4 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
 
 browser.browserAction.onClicked.addListener(executeJs);
 browser.tabs.onUpdated.addListener(resetBadgeText);
+iniitalizeUrl();

--- a/manifest.json
+++ b/manifest.json
@@ -30,8 +30,9 @@
       }
     ]
   },
-  "permissions": ["<all_urls>", "contextMenus"],
+  "permissions": ["<all_urls>", "contextMenus", "storage"],
   "background": {
     "scripts": ["browser-polyfill.js", "background.js"]
-  }
+  },
+  "options_page": "options.html"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "manifest_version": 2,
   "name": "Sci-Hub Now!",
   "short_name": "sci-hub-now",
-  "version": "0.0.2",
-  "author": "Orçun Özdemir",
-  "homepage_url": "https://github.com/0x01h/sci-hub-now",
+  "version": "0.0.3",
+  "author": "Orçun Özdemir and Lucas Sterzinger and Gerry Chen",
+  "homepage_url": "https://github.com/lsterzinger/sci-hub-now",
   "description": "Free access to academic papers with just a single click! Abolish publishers, long live the open access movement!",
   "icons": {
     "48": "icons/48x48.png",

--- a/options.html
+++ b/options.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Sci-hub Now!</h1>
+    <div style="display:flex; flex-direction: row; justify-content: left; align-items: center">
+      <p style="margin-right: 1em;">Sci-Hub url:</p>
+      <input type="text" id="url"/>
+    </div>
+    <div>
+      <p>
+        Please visit the <a href="https://github.com/0x01h/sci-hub-now/issues">github</a> to give feedback.
+      </p>
+    </div>
+  </body>
+  <script src="options.js"></script>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function getUrl(field) {
+  chrome.storage.local.get(['scihub-url'], function (result) {
+    field.value = result['scihub-url'];
+  })
+}
+
+function setUrl(url) {
+  chrome.storage.local.set({'scihub-url': url}, function () {})
+  var bgPage = chrome.extension.getBackgroundPage();
+  bgPage.setUrl(url);
+}
+
+var urlField = document.getElementById("url");
+getUrl(urlField);
+urlField.onkeyup = function () {
+  setUrl(urlField.value);
+};


### PR DESCRIPTION
### Please redirect to [my fork](https://github.com/gchenfc/sci-hub-now/tree/master) - I am willing to maintain it for the remainder of my PhD (~early 2024???).

Allows for end-users to update the scihub TLD url through the "options" page.

Extremely minimalist options page accessed by right clicking bird icon > "Options"

![image](https://user-images.githubusercontent.com/25356161/95601568-a1390800-0a21-11eb-9fc3-7a4b2501f716.png)
